### PR TITLE
feat: light mode and dark mode toggle state in browsers local storage

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,7 +5,7 @@ import Home from "./scenes/Home";
 import Login from "./scenes/Login";
 import Profile from "./scenes/Profile";
 import { useSelector, useDispatch } from "react-redux";
-import { setLogout, setLogin } from "./state";
+import { setLogout, setLogin, setModeState} from "./state";
 import { useMemo } from "react";
 import { CssBaseline, ThemeProvider } from "@mui/material";
 import { createTheme } from "@mui/material/styles";
@@ -18,6 +18,15 @@ const App = () => {
   const theme = useMemo(() => createTheme(themeSettings(mode)), [mode]);
   const user = JSON.parse(localStorage.getItem("user"));
   const dispatch = useDispatch();
+  useEffect(()=>{
+    if(localStorage.getItem("sociopediaMode") === null){
+      localStorage.setItem("sociopediaMode", mode)
+    }
+    else{
+      dispatch(setModeState({"sociopediaMode": localStorage.getItem("sociopediaMode")}))
+    }
+  }, [])
+
   useEffect(() => {
     function checkAuthentication() {
       if (user?.token) {

--- a/frontend/src/state/index.js
+++ b/frontend/src/state/index.js
@@ -11,8 +11,12 @@ export const authSlice = createSlice({
   name: "auth",
   initialState,
   reducers: {
+    setModeState: (state, action) =>{
+      state.mode = action.payload.sociopediaMode
+    },
     setMode: (state) => {
       state.mode = state.mode === "light" ? "dark" : "light";
+      localStorage.setItem("sociopediaMode", state.mode)
     },
     setLogin: (state, action) => {
       state.user = action.payload.user;
@@ -45,7 +49,7 @@ export const authSlice = createSlice({
   },
 });
 
-export const { setMode, setLogin, setLogout, setFriends, setPosts, setPost } =
+export const { setMode, setLogin, setLogout, setFriends, setPosts, setPost, setModeState } =
   authSlice.actions;
 
 export default authSlice.reducer;


### PR DESCRIPTION
Fixes Issue #36 

**Changes done**

1. When the Application is rendered, this part of the code in `src/App.js` will check if the toggle mode is `light` mode or `dark` mode. If the mode itself is don't exist in local storage, it will assign the default mode in the store's initial state.
 <img width="558" alt="Screenshot 2023-06-27 at 11 47 35 PM" src="https://github.com/rawasaditya/SocioPedia/assets/57148990/d026a538-0a5a-4656-a392-eafea1385569">

2. Added a new reducer to set the mode state and whenever the mode is changed from `light` to `dark` or vice-versa the storage gets updated.
<img width="433" alt="Screenshot 2023-06-28 at 12 00 33 AM" src="https://github.com/rawasaditya/SocioPedia/assets/57148990/e1cd3cf7-9ac2-497e-b315-6856f4c35401">
